### PR TITLE
Disable warnings-as-errors to make DCD work again

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -34,5 +34,8 @@
 	"dependencies": {
 		"libdparse": "~master",
 		"msgpack-d": "~master"
-	}
+	},
+	"buildRequirements": [
+		"silenceWarnings"
+	]
 }


### PR DESCRIPTION
The currently imported third party version of DCD produces warnings with the latest DMD version which make the DUB build process fail. This change makes warnings silent (still shows them won't let the build fail). 

Fixes #1 
